### PR TITLE
don't fall over for some status conflicts

### DIFF
--- a/src/ssda/database/sdb.py
+++ b/src/ssda/database/sdb.py
@@ -22,6 +22,7 @@ from ssda.util.fits import (
 )
 from ssda.util.salt_fits import parse_start_datetime
 from ssda.util.types import ProposalType
+from ssda.util.warnings import record_warning
 
 
 class BlockVisitIdStatus(Enum):
@@ -798,11 +799,19 @@ class SaltDatabaseService:
                     fd.block_visit_id in status_values
                     and status_values[fd.block_visit_id] != fd.block_visit_id_status
                 ):
-                    raise Exception(
-                        f"The block visit id {fd.block_visit_id} has been "
-                        f"marked both as {status_values[fd.block_visit_id]} "
-                        f"and {fd.block_visit_id_status}."
-                    )
+                    if status_values[fd.block_visit_id] == BlockVisitIdStatus.CONFIRMED:
+                        record_warning(Warning(
+                            f"The block visit id {fd.block_visit_id} has been "
+                            f"marked both as {status_values[fd.block_visit_id]} "
+                            f"and {fd.block_visit_id_status}."
+                        ))
+                        fd.block_visit_id_status = BlockVisitIdStatus.CONFIRMED
+                    else:
+                        raise Exception(
+                            f"The block visit id {fd.block_visit_id} has been "
+                            f"marked both as {status_values[fd.block_visit_id]} "
+                            f"and {fd.block_visit_id_status}."
+                        )
                 status_values[fd.block_visit_id] = fd.block_visit_id_status
 
         # ... and update the inferred and guessed status values accordingly.


### PR DESCRIPTION
There can be a conflict of block visit id status values if a block has more than one teget.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saltastroops/data-archive-database/192)
<!-- Reviewable:end -->
